### PR TITLE
change VMD_HOME to VMD_CHEM_HOME

### DIFF
--- a/pwchem/constants.py
+++ b/pwchem/constants.py
@@ -35,7 +35,7 @@ JCHEM_DIC =     {'name': 'jchempaint',  'version': '3.2.0',         'home': 'JCH
 OPENBABEL_DIC = {'name': 'openbabel',   'version': '2.2',           'home': 'OPENBABEL_HOME'}
 ALIVIEW_DIC =   {'name': 'aliview',     'version': '1.28',          'home': 'ALIVIEW_HOME'}
 SHAPEIT_DIC =   {'name': 'shape-it',    'version': '2.0.0',         'home': 'SHAPEIT_HOME'}
-VMD_DIC =       {'name': 'vmd',         'version': '1.9.3',         'home': 'VMD_HOME'}
+VMD_DIC =       {'name': 'vmd',         'version': '1.9.3',         'home': 'VMD_CHEM_HOME'}
 RDKIT_DIC =     {'name': 'rdkit',       'version': DEFAULT_VERSION, 'home': 'RDKIT_HOME'}
 BIOCONDA_DIC =  {'name': 'bioconda',    'version': DEFAULT_VERSION}
 


### PR DESCRIPTION
pwem VmdView (used by continuousflex and prody) requires VMD_HOME to be set but installing scipion-chem does not work if it is. It could also be good to be able to have different versions of VMD in case the two sides of Scipion have different requirements.

Giving non-conflicting names makes the installation work