### PR TITLE
fix pipe in seq id

### DIFF
--- a/pwchem/objects/base.py
+++ b/pwchem/objects/base.py
@@ -1306,7 +1306,7 @@ class ProteinResidue(data.EMObject):
 
 
 class MDSystem(data.EMFile):
-    """A system atom structure (prepared for MD). Base class fro Gromacs, Amber
+    """A system atom structure (prepared for MD). Base class for Gromacs, Amber
         _topoFile: topology file
         _trjFile: trajectory file
         _ff: main force field

--- a/pwchem/wizards/wizard_select_chain.py
+++ b/pwchem/wizards/wizard_select_chain.py
@@ -719,7 +719,7 @@ class AddSequenceWizard(SelectResidueWizard):
             outStr = [os.path.splitext(os.path.basename(pdbFile))[0]]
             AS = True
         elif issubclass(type(inputObj), Sequence):
-            outStr = [inputObj.getId()]
+            outStr = [inputObj.getId().replace("|", "_")]
 
         if AS:
             # Chain


### PR DESCRIPTION
Fasta files from the PDB website can have a pipe in the header e.g.
```>7XIW_1|Chains A, B, C[auth D]|Spike glycoprotein|Severe acute respiratory syndrome coronavirus 2 (2697049)```

This gets passed through define set of sequences to modeller, which then uses it in filenames, making problems for downstream protocols.

This fix changes the pipe to an underscore