### PR TITLE
JMK converter fixes

### DIFF
--- a/pwchem/protocols/General/protocol_converter.py
+++ b/pwchem/protocols/General/protocol_converter.py
@@ -187,8 +187,8 @@ class ConvertStructures(EMProtocol):
                         parmed.gromacs.GROMACS_TOPDIR = gromacsPlugin._getLocation(GROMACS_DIC, marker='GROMACS_INSTALLED') + '/share/top'
 
                     top = parmed.load_file(topFile)
-                    topFile = self._getPath('{}.{}'.format(getBaseName(topFile),
-                                                            self.getEnumText('outputTopFormat').lower()))
+                    topFile = self._getExtraPath('{}.{}'.format(getBaseName(topFile),
+                                                                self.getEnumText('outputTopFormat').lower()))
                     top.save(topFile)
                 outSystem.setTopologyFile(topFile)
             


### PR DESCRIPTION
1. There was the "Trajectory output format" label twice, so now we have Topology and Trajectory labels.
2. Fix topology conversion itself to let parmed find gromacs topologies using gromacs plugin _getLocation helper function added in https://github.com/scipion-chem/scipion-chem-gromacs/pull/25
3. Fix system file structure conversion to have abspath for input file and . in .pdb for output
4. Have topology in extra path like others