### PR TITLE
fix(scorch2): drop stray Windows-only ctypes.wintypes import

### DIFF
--- a/pwchem/protocols/VirtualDrugScreening/protocol_scorch2_pose.py
+++ b/pwchem/protocols/VirtualDrugScreening/protocol_scorch2_pose.py
@@ -32,7 +32,6 @@ SCORCH2 (SC2) is a machine learning rescoring model designed for interaction-bas
 """
 import csv
 import logging
-# from ctypes.wintypes import SMALL_RECT
 from pathlib import Path
 from pwem.convert import cifToPdb
 

--- a/pwchem/protocols/VirtualDrugScreening/protocol_scorch2_pose.py
+++ b/pwchem/protocols/VirtualDrugScreening/protocol_scorch2_pose.py
@@ -32,7 +32,7 @@ SCORCH2 (SC2) is a machine learning rescoring model designed for interaction-bas
 """
 import csv
 import logging
-from ctypes.wintypes import SMALL_RECT
+# from ctypes.wintypes import SMALL_RECT
 from pathlib import Path
 from pwem.convert import cifToPdb
 


### PR DESCRIPTION
`from ctypes.wintypes import SMALL_RECT` (an accidental IDE auto-import, never used) raises ImportError on Linux/macOS, breaking the scorch2 pose protocol module. Comment it out.